### PR TITLE
add support for string body

### DIFF
--- a/lib/renderers/html/templates/partials/sample.hbs
+++ b/lib/renderers/html/templates/partials/sample.hbs
@@ -62,9 +62,9 @@
       {{#hasKeys response.headers}}
         <a href="#sample{{id}}-response-headers">headers</a>
       {{/hasKeys}}
-      {{#hasKeys response.body}}
+      {{#if response.body}}
         <a href="#sample{{id}}-response-body">body</a>
-      {{/hasKeys}}
+      {{/if}}
     </div>
   </div>
 


### PR DESCRIPTION
Renders response body as long as it exists, this makes it work with any type of body instead of just Object.
