### PR TITLE
Don't use a global in capture.js, or else deep.extend fails in horrible ways

### DIFF
--- a/lib/capture.js
+++ b/lib/capture.js
@@ -1,5 +1,7 @@
 var deep = require('deep');
 
+var data;
+
 // capture extra data about the currently running test
 // this is reset between each test
 


### PR DESCRIPTION
Specifically, if any other packages being used are also abusing global variables, and they happen to assign an array to the global `data`, `deep.extend` just doesn't extend it, making later code that relies on `request` existing crash horribly!
