### PR TITLE
return null if route is undefined under 404 error.

### DIFF
--- a/lib/instruments/restify.js
+++ b/lib/instruments/restify.js
@@ -17,6 +17,11 @@ exports.find = function(req, res, fn) {
 };
 
 exports.route = function(route, params) {
+  // if error is 404, the route would be undefined
+  if (!route) {
+    return null;
+  }
+
   if (params != '') {
     return route.spec.path + '?' + params;
   } else {

--- a/test/instruments/restify.spec.js
+++ b/test/instruments/restify.spec.js
@@ -13,6 +13,11 @@ describe('instruments / restify', function() {
       var route = instrument.route({spec:{path:'/url/:id'}}, 'param1=$param1')
       route.should.eql('/url/:id?param1=$param1');
     })
+
+    it('should return null if route does not exists', function () {
+      var route = instrument.route();
+      should.not.exist(route);
+    })
   });
 
   describe('params', function() {


### PR DESCRIPTION
when 404 restify error thrown, the param `route` would be undefined in `exports.route` in `instrument/restify.js`
