### PR TITLE
Fix bug where supersamples would not run without a supersamples.opt file

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -21,7 +21,7 @@ var DEFAULTS = {
 };
 
 exports.read = function() {
-  if (fs.exists(OPTS_FILE) === false) {
+  if (fs.existsSync(OPTS_FILE) === false) {
     return DEFAULTS;
   }
   try {
@@ -38,4 +38,3 @@ exports.get = function() {
   if (!data) data = exports.read();
   return data;
 };
-


### PR DESCRIPTION
`fs.exists` is async so always returns `undefined`
