### PR TITLE
Fix module require patching

### DIFF
--- a/lib/patch-require.js
+++ b/lib/patch-require.js
@@ -4,7 +4,6 @@ var module = require('module');
 var _load = module._load;
 
 var moduleNames = {};
-var processed = [];
 
 exports.module = function(name, fn) {
   moduleNames[name] = fn;
@@ -13,11 +12,10 @@ exports.module = function(name, fn) {
 module._load = function(path) {
   var mdl = _load.apply(this, arguments);
   var hasPatch = moduleNames.hasOwnProperty(path)
-  var alreadyProcessed = processed.indexOf(path) > -1;
-  if (hasPatch && !alreadyProcessed) {
+  if (hasPatch && !mdl.__supersamplesPatched) {
     console.log('Instrumenting ', path)
     moduleNames[path](mdl);
-    processed.push(path);
+    mdl.__supersamplesPatched = true;
   }
   return mdl;
 };


### PR DESCRIPTION
@rprieto, In the old implementation, the patch is only performed once for all require statements. This is problematic if, for example, a project that requires `restify` also has one or more modules that also requires `restify`. The old implementation would only patch the first required `restify`. 