### PR TITLE
Update instruments to match the supertest API

### DIFF
--- a/lib/instruments/supertest.js
+++ b/lib/instruments/supertest.js
@@ -2,12 +2,19 @@ var _       = require('lodash');
 var capture = require('../capture');
 
 
-exports.assert = function(response, fn) {
+exports.assert = function(/*[error,] response, fn*/) {
+  var response;
+  if (this.__shimmed.assert.length < 3) {
+    response = arguments[0];
+  } else {
+    response = arguments[1];
+  }
+
   capture.add({
     request: extractRequest(this),
     response: extractResponse(this, response)
   });
-  return this.__shimmed.assert.call(this, response, fn);
+  return this.__shimmed.assert.apply(this, arguments);
 };
 
 // These headers are set on every request


### PR DESCRIPTION
supertest add `resError` as the first parameter of `Test#assert()` since 1.0.0 ([commit](https://github.com/visionmedia/supertest/blob/8c382ee45ca4e97ad0347a221617c1ae375e6c53/lib/test.js#L146)), so
we need to change the instrument to match the new signature.

Also upgrade dependent version of supertest.