### PR TITLE
Clear supersamples name for each test

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -15,6 +15,7 @@ function MyReporter(runner) {
 
   runner.on('test', function(test) {
     capture.reset();
+    test.ctx.supersamples = null;
   });
 
   runner.on('pass', function(test) {


### PR DESCRIPTION
When a supersamples name is set using `@supersamples = { name: 'valid list' }`, the name is then set for all tests that run after the test that set the name.

This makes the reporter clear out the supersample data for each test so that the subsequent tests do not use the incorrect supersample data.