### PR TITLE
Fix #23: support for any Mocha reporter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ npm test
 ## Building the example docs (website, json, markdown)
 
 ```bash
-make clean example/build
+make clean example-docs
 ```
 
 ## Deploying the example docs to Github pages

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ You also need to specify documentation options in a **supersamples.opts** file a
   // Base URL for the API
   "baseUrl": "http://my-api.com",
 
+  // Mocha reporter to display test results
+  // e.g. Dot, TAP, Spec...
+  "reporter": "Dot",
+
   // One or more rendering modes
   // And their associated options
   "renderers": {

--- a/lib/options.js
+++ b/lib/options.js
@@ -9,6 +9,7 @@ var OPTS_FILE = 'supersamples.opts';
 
 var DEFAULTS = {
   baseUrl: 'http://localhost',
+  reporter: 'Dot',
   renderers: {
     html: {
       outputFolder: './tmp',

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,11 +1,18 @@
 var path      = require('path');
 var mocha     = require('mocha');
+var options   = require('./options');
 var capture   = require('./capture');
 var sample    = require('./model/sample');
 var samples   = require('./model/samples');
 var render    = require('./render');
 
-var Base = mocha.reporters.Dot;
+var reporter = options.get().reporter;
+var Base = mocha.reporters[reporter];
+
+if (!Base) {
+  console.error('Invalid mocha reporter: ' + reporter);
+  process.exit(1);
+}
 
 samples.reset();
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "deep": "0.0.2"
   },
   "devDependencies": {
-    "mocha": "~1.20.0",
+    "mocha": "~2.2.5",
     "should": "~4.0.4",
     "supertest": "~0.13.0",
     "coffee-script": "~1.7.1",

--- a/supersamples.opts
+++ b/supersamples.opts
@@ -9,6 +9,9 @@
   // Base URL for all API calls (used in CURL examples)
   "baseUrl": "http://my-api.com",
 
+  // Mocha reporter to display test results
+  // e.g. Dot, TAP, Spec...
+  "reporter": "Dot",
 
   //
   // Renderers


### PR DESCRIPTION
This adds a new option to `supersamples.opts`:

```js
{
  "reporter": "Dot"   // Dot, Spec, TAP...
}
```

The names are as defined in https://github.com/mochajs/mocha/blob/master/lib/reporters/index.js.
:warning: The latest published version of Mocha doesn't include the *lowercase* names yet, so we have to use the *CamelCase* ones.
