### PR TITLE
Feature / render to postman collection (V2)

### DIFF
--- a/lib/renderers/postman/README.md
+++ b/lib/renderers/postman/README.md
@@ -16,7 +16,13 @@ You can specify the following in your `supersamples.opts`:
       "title": "Postman Collection Title"
 
       // Format version (optional) - currently only postmanV2 is supported
-      "version": 2
+      "version": 2,
+      
+      // Generate a postman test suite
+      "generateTests": true,
+
+      // Additional postman variables
+      "variables": []
 
     }
 

--- a/lib/renderers/postman/README.md
+++ b/lib/renderers/postman/README.md
@@ -1,0 +1,28 @@
+# Postman renderer
+
+You can specify the following in your `supersamples.opts`:
+
+```js
+{
+
+  "renderers": {
+
+    "postman": {
+
+      // Relative path to the output file
+      "outputFile": "path/to/file.postman_collection",
+      
+      // Collection title
+      "title": "Postman Collection Title"
+
+      // Format version (optional) - currently only postmanV2 is supported
+      "version": 2
+
+    }
+
+  }
+
+}
+```
+
+Which will generate a postman collection

--- a/lib/renderers/postman/index.js
+++ b/lib/renderers/postman/index.js
@@ -46,14 +46,13 @@ var findFolder = function (sample) {
   return null;
 }
 
-module.exports.render = function (model, options) {
+module.exports.render = function (samples, options) {
 
   // create the output folder
   var outputFolder = path.dirname(options.outputFile);
   fs.mkdirpSync(outputFolder);
 
   // write the view as JSON
-  var samples = options.objectWrapper ? { samples: model } : model;
   var content = view(samples, options);
   fs.writeFileSync(options.outputFile, content);
 

--- a/lib/renderers/postman/index.js
+++ b/lib/renderers/postman/index.js
@@ -1,0 +1,80 @@
+var _          = require('lodash');
+var fs         = require('fs-extra');
+var path       = require('path');
+
+var templates  = {
+  root:   require('./templates/root'),
+  folder: require('./templates/folder'),
+  sample: require('./templates/sample')
+};
+
+var folders = {};
+
+var getFolderHash = function (sampleHierarchy) {
+  var hierarchy = _.cloneDeep(sampleHierarchy);
+  if (hierarchy.length > 2) {
+    hierarchy.splice(-1, 1); // remove the test name
+    return hierarchy.join('-');
+  }
+
+  return null;
+};
+
+var createFolder = function (sample, dest) {
+  var folderHash = getFolderHash(sample.hierarchy);
+
+  if (folderHash) {
+    var folderName = folderHash.split('-').pop();
+    var folder = templates.folder({ name: folderName });
+    folders[folderHash] = folder;
+
+    if (dest) dest.push(folder);
+
+    return folder;
+  }
+
+  return null;
+};
+
+var findFolder = function (sample) {
+  var folderHash = getFolderHash(sample.hierarchy);
+
+  if (folderHash && folders[folderHash]) {
+    return folders[folderHash];
+  }
+
+  return null;
+}
+
+module.exports.render = function (model, options) {
+
+  // create the output folder
+  var outputFolder = path.dirname(options.outputFile);
+  fs.mkdirpSync(outputFolder);
+
+  // write the view as JSON
+  var samples = options.objectWrapper ? { samples: model } : model;
+  var content = view(samples, options);
+  fs.writeFileSync(options.outputFile, content);
+
+  console.log('Generated in ' + path.resolve(options.outputFile));
+
+};
+
+function view (samples, options) {
+  var data = templates.root(samples, options);
+
+  data.item = []; // main collection container
+
+  samples.forEach(function (sample) {
+    // add a folder if needed
+    var folder = findFolder(sample) || createFolder(sample, data.item);
+    var sampleContainer = folder ? folder.item : data.item;
+
+    var sample = templates.sample(sample, options);
+
+    sampleContainer.push(sample);
+  });
+
+  return JSON.stringify(data, null, 2);
+}

--- a/lib/renderers/postman/index.js
+++ b/lib/renderers/postman/index.js
@@ -10,40 +10,37 @@ var templates  = {
 
 var folders = {};
 
-var getFolderHash = function (sampleHierarchy) {
-  var hierarchy = _.cloneDeep(sampleHierarchy);
-  if (hierarchy.length > 2) {
-    hierarchy.splice(-1, 1); // remove the test name
-    return hierarchy.join('-');
-  }
+var folderHashSeparator = '🙉';
 
-  return null;
+var getFolderHash = function (sampleHierarchy) {
+  if (sampleHierarchy.length < 3) return null;
+
+  var hierarchy = _.cloneDeep(sampleHierarchy);
+  hierarchy.splice(-1, 1); // remove the test name
+
+  return hierarchy.join(folderHashSeparator);
 };
 
 var createFolder = function (sample, dest) {
   var folderHash = getFolderHash(sample.hierarchy);
 
-  if (folderHash) {
-    var folderName = folderHash.split('-').pop();
-    var folder = templates.folder({ name: folderName });
-    folders[folderHash] = folder;
+  if (!folderHash) return null;
 
-    if (dest) dest.push(folder);
+  var folderName = folderHash.split(folderHashSeparator).pop();
+  var folder = templates.folder({ name: folderName });
+  folders[folderHash] = folder;
 
-    return folder;
-  }
+  if (dest) dest.push(folder);
 
-  return null;
+  return folder;
 };
 
 var findFolder = function (sample) {
   var folderHash = getFolderHash(sample.hierarchy);
 
-  if (folderHash && folders[folderHash]) {
-    return folders[folderHash];
-  }
+  if (!folderHash || !folders[folderHash]) return null;
 
-  return null;
+  return folders[folderHash];
 }
 
 module.exports.render = function (samples, options) {

--- a/lib/renderers/postman/templates/events/test-response-200.js
+++ b/lib/renderers/postman/templates/events/test-response-200.js
@@ -1,9 +1,0 @@
-'use strict';
-
-module.exports = {
-    listen: "test",
-    script: {
-        type: "text/javascript",
-        exec: "tests[\"Status code is 200\"] = responseCode.code === 200;"
-    }
-};

--- a/lib/renderers/postman/templates/events/test-response-200.js
+++ b/lib/renderers/postman/templates/events/test-response-200.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+    listen: "test",
+    script: {
+        type: "text/javascript",
+        exec: "tests[\"Status code is 200\"] = responseCode.code === 200;"
+    }
+};

--- a/lib/renderers/postman/templates/events/test-status-code.js
+++ b/lib/renderers/postman/templates/events/test-status-code.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function (data, opts) {
+    return {
+        listen: 'test',
+        script: {
+            type: 'text/javascript',
+            exec: 'tests[\"Status code is '+ (data.statusCode) +'\"] = responseCode.code === '+ (data.statusCode) +';'
+        }
+    };
+};

--- a/lib/renderers/postman/templates/folder.js
+++ b/lib/renderers/postman/templates/folder.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function (data, opts) {
+    return {
+        name: data.name,
+        description: data.description || '',
+        item: []
+    };
+}

--- a/lib/renderers/postman/templates/root.js
+++ b/lib/renderers/postman/templates/root.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function (data, opts) {
+    return {
+        variables: opts.variables || [],
+        info: {
+            name: opts.title,
+            _postman_id: opts._postman_id || '',
+            description: '',
+            schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+        }
+    };
+}

--- a/lib/renderers/postman/templates/sample.js
+++ b/lib/renderers/postman/templates/sample.js
@@ -40,7 +40,7 @@ module.exports = function (data, opts) {
     }
 
     // add tests
-    if (data.response.status) {
+    if (opts.generateTests && data.response.status) {
         template.event.push(testStatusCode({ statusCode: data.response.status }));
     }
 

--- a/lib/renderers/postman/templates/sample.js
+++ b/lib/renderers/postman/templates/sample.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var testResponse200 = require('./events/test-response-200');
+
+module.exports = function (data, opts) {
+    data.request = data.request || {};
+
+    var template =  {
+        name: data.name || 'Sample',
+        event: [
+            testResponse200
+        ],
+        request: {
+            url: '{{ hostUrl }}' + data.request.path,
+            method: data.request.method || 'GET',
+            header: (function () {
+                return Object.keys(data.request.headers || {}).map(function(key) {
+                    return {
+                        key: key,
+                        value: data.request.headers[key],
+                        description: ''
+                    };
+                });
+            })(),
+            description: data.summary || data.name || ''
+        },
+        response: []
+    };
+
+    if (data.request.method && data.request.method !== 'GET') {
+        template.request.body = {
+            mode: 'raw',
+            raw: JSON.stringify(data.request.data || '', null, 2)
+        }
+    }
+    else {
+        template.request.body = {
+            mode: 'formdata',
+            formdata: []
+        }
+    }
+
+    return template;
+}

--- a/lib/renderers/postman/templates/sample.js
+++ b/lib/renderers/postman/templates/sample.js
@@ -41,7 +41,7 @@ module.exports = function (data, opts) {
 
     // add tests
     if (data.response.status) {
-        template.event.push(testStatusCode(data.response.status));
+        template.event.push(testStatusCode({ statusCode: data.response.status }));
     }
 
     return template;

--- a/lib/renderers/postman/templates/sample.js
+++ b/lib/renderers/postman/templates/sample.js
@@ -1,15 +1,13 @@
 'use strict';
 
-var testResponse200 = require('./events/test-response-200');
+var testStatusCode = require('./events/test-status-code');
 
 module.exports = function (data, opts) {
     data.request = data.request || {};
 
     var template =  {
         name: data.name || 'Sample',
-        event: [
-            testResponse200
-        ],
+        event: [],
         request: {
             url: '{{ hostUrl }}' + data.request.path,
             method: data.request.method || 'GET',
@@ -24,9 +22,10 @@ module.exports = function (data, opts) {
             })(),
             description: data.summary || data.name || ''
         },
-        response: []
+        response: [],
     };
 
+    // add body
     if (data.request.method && data.request.method !== 'GET') {
         template.request.body = {
             mode: 'raw',
@@ -38,6 +37,11 @@ module.exports = function (data, opts) {
             mode: 'formdata',
             formdata: []
         }
+    }
+
+    // add tests
+    if (data.response.status) {
+        template.event.push(testStatusCode(data.response.status));
     }
 
     return template;

--- a/supersamples.opts
+++ b/supersamples.opts
@@ -72,7 +72,8 @@
       "variables": [],
       "version": 2, // others not supported at the moment
       "generateTests": true
-    }
+
+    },
 
 
     //

--- a/supersamples.opts
+++ b/supersamples.opts
@@ -64,6 +64,16 @@
 
     },
 
+    "postman": {
+
+      // Output file path
+      "outputFile": "example-docs/samples.json",
+      "title": "Postman Collection Title",
+      "variables": [],
+      "version": 2, // others not supported at the moment
+      "generateTests": true
+    }
+
 
     //
     // Single Markdown file


### PR DESCRIPTION
@rprieto 
rendering test output to a postman collection (currently only postman v2 format is supported)

There are quite a few more features that could be added (as well as some tests) - so I will most likely tweak this branch a bit more.

At the moment it covers basic postman functionality + can also generate folders for nested `describe` blocks inside the postman collection.