### PR TITLE
Instrument express

### DIFF
--- a/lib/instrument.js
+++ b/lib/instrument.js
@@ -4,7 +4,8 @@ var patch = require('./patch-require');
 var instruments = {
   superagent: require('./instruments/superagent'),
   supertest:  require('./instruments/supertest'),
-  restify:    require('./instruments/restify')
+  restify:    require('./instruments/restify'),
+  express:    require('./instruments/express')
 }
 
 var sandbox = sinon.sandbox.create();
@@ -12,21 +13,26 @@ var sandbox = sinon.sandbox.create();
 exports.setup = function() {
 
   patch.module('superagent', function(instance) {
-    Request = instance.Request;
+    var Request = instance.Request;
     replace(Request.prototype, 'write', instruments.superagent.write);
     replace(Request.prototype, 'attach', instruments.superagent.attach);
   });
 
   patch.module('supertest', function(instance) {
-    Test = instance.Test;
+    var Test = instance.Test;
     replace(Test.prototype, 'expect', instruments.supertest.expect);
     replace(Test.prototype, 'assert', instruments.supertest.assert);
   });
 
   patch.module('restify', function(instance) {
     var dummyServer = instance.createServer();
-    Router = dummyServer.router.constructor;
+    var Router = dummyServer.router.constructor;
     replace(Router.prototype, 'find', instruments.restify.find);
+  });
+
+  patch.module('express', function(instance) {
+    var Router = instance.Router;
+    replace(Router, 'process_params', instruments.express.processParams);
   });
 
 };

--- a/lib/instruments/express.js
+++ b/lib/instruments/express.js
@@ -1,0 +1,37 @@
+var _       = require('lodash');
+var url     = require('url');
+var capture = require('../capture');
+
+
+exports.processParams = function(layer, called, req, res, fn) {
+  if (layer.route) {
+    var params = exports.params(url.parse(req.url, true).query)
+
+    capture.add({
+      request: {
+        route: exports.route(layer.route, params)
+      }
+    });
+  }
+
+  return this.__shimmed.process_params.call(this, layer, called, req, res, fn);
+};
+
+exports.route = function(route, params) {
+  // if error is 404, the route would be undefined
+  if (!route) {
+    return null;
+  }
+
+  if (params != '') {
+    return route.path + '?' + params;
+  } else {
+    return route.path;
+  }
+};
+
+exports.params = function(params) {
+  return _.map(params, function(value, key) {
+    return key + "=$" + key;
+  }).join('&')
+};

--- a/lib/model/sample.js
+++ b/lib/model/sample.js
@@ -6,7 +6,7 @@ exports.create = function(mochaTest, request, response) {
     summary: mochaTest.title,
     hierarchy: hierarchy(mochaTest),
     request: request,
-    response: response,
+    response: formatResponse(response),
     snippets: {
       curl: curl.fromRequest(request)
     }
@@ -24,4 +24,13 @@ function hierarchy(mochaTest) {
     return hierarchy(mochaTest.parent).concat(shortName);
   }
   return [];
+}
+
+function formatResponse(response) {
+  if (typeof response.body === 'string') {
+    try {
+      response.body = JSON.parse(response.body);
+    } catch (err) {}
+  }
+  return response;
 }

--- a/test/end-to-end/express.spec.js
+++ b/test/end-to-end/express.spec.js
@@ -1,0 +1,185 @@
+var express = require('express')
+var should  = require('should');
+var request = require('supertest');
+var capture = require('../../lib/capture');
+
+describe('instrument express / supertest / superagent', function() {
+
+  beforeEach(function() {
+    capture.reset();
+  });
+
+  describe('request', function() {
+
+    var server = express()
+    server.get('/foo/:bar', function(req, res) {
+      res.send({ hello: req.params.bar })
+    })
+    server.post('/foo', function(req, res) {
+      res.send({ hello: 'world' })
+    })
+
+    it('inspects the method and path', function(done) {
+      request(server)
+      .get('/foo/bar')
+      .end(function() {
+        capture.get().request.should.eql({
+          headers: {},
+          method: 'GET',
+          path: '/foo/bar',
+          route: '/foo/:bar'
+        });
+        done();
+      });
+    });
+
+    it('inspects custom headers', function(done) {
+      request(server)
+      .get('/foo/bar')
+      .set('x-custom', '1234')
+      .end(function() {
+        capture.get().request.should.eql({
+          headers: {
+            'x-custom': '1234'
+          },
+          method: 'GET',
+          path: '/foo/bar',
+          route: '/foo/:bar'
+        });
+        done();
+      });
+    });
+
+    it('ignores headers with no value, or from the blacklist', function(done) {
+      request(server)
+      .get('/foo/bar')
+      .set('accept-encoding', 'text/plain')
+      .set('x-custom', '')
+      .end(function() {
+        capture.get().request.should.eql({
+          headers: {},
+          method: 'GET',
+          path: '/foo/bar',
+          route: '/foo/:bar'
+        });
+        done();
+      });
+    });
+
+    it('inspects JSON payloads', function(done) {
+      request(server)
+      .post('/foo')
+      .send({value: 1234})
+      .end(function() {
+        capture.get().request.should.eql({
+          data: {
+            value: 1234
+          },
+          headers: {
+            'content-type': 'application/json',
+            'content-length': 14
+           },
+          method: 'POST',
+          path: '/foo',
+          route: '/foo'
+        });
+        done();
+      });
+    });
+
+    it('inspects binary payloads', function(done) {
+      req = request(server).post('/foo')
+      req.write(new Buffer([0x01, 0x02, 0x03, 0x04]))
+      req.end(function() {
+        capture.get().request.should.eql({
+          data: new Buffer([0x01, 0x02, 0x03, 0x04]),
+          headers: {},
+          method: 'POST',
+          path: '/foo',
+          route: '/foo'
+        });
+        done();
+      });
+    });
+
+  });
+
+  describe('response', function() {
+
+    it('inspects the response status and body', function(done) {
+      var server = express()
+      server.get('/foo/:bar', function(req, res) {
+        res.send('hello world')
+      })
+      request(server)
+      .get('/foo/bar')
+      .end(function(err, res) {
+        capture.get().response.should.eql({
+          status: 200,
+          headers: {},
+          body: 'hello world',
+        });
+        done();
+      });
+    });
+
+    it('can inspect JSON bodies as well', function(done) {
+      var server = express()
+      server.get('/foo/:bar', function(req, res) {
+        res.set('Content-Type', 'application/json');
+        res.send(JSON.stringify({hello: 'world'}))
+      })
+      request(server)
+      .get('/foo/bar')
+      .end(function(err, res) {
+        capture.get().response.should.eql({
+          status: 200,
+          headers: {},
+          body: {hello: 'world'},
+        });
+        done();
+      });
+    });
+
+    it('can inspect responses with no bodies', function(done) {
+      var server = express()
+      server.get('/foo/:bar', function(req, res) {
+        res.send()
+      })
+      request(server)
+      .get('/foo/bar')
+      .end(function(err, res) {
+        capture.get().response.should.eql({
+          status: 200,
+          headers: {},
+          body: '',
+        });
+        done();
+      });
+    });
+
+    it('extracts headers that were asserted on', function(done) {
+      var server = express()
+      server.get('/foo/:bar', function(req, res) {
+        res.set('Content-Type', 'text/plain');
+        res.set('X-Transaction-Id', '999')
+        res.send('hello world')
+      })
+      request(server)
+      .get('/foo/bar')
+      .expect('x-transaction-id', '999')
+      .end(function(err, res) {
+        capture.get().response.should.eql({
+          status: 200,
+          headers: {
+            'x-transaction-id': '999'
+          },
+          body: 'hello world',
+        });
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/instruments/express.spec.js
+++ b/test/instruments/express.spec.js
@@ -1,0 +1,30 @@
+var should     = require('should');
+var instrument = require('../../lib/instruments/express');
+
+describe('instruments / express', function() {
+
+  describe('route', function() {
+    it('should create route without params', function() {
+      var route = instrument.route({path:'/url/:id'}, '')
+      route.should.eql('/url/:id');
+    })
+
+    it('should create route with params', function() {
+      var route = instrument.route({path:'/url/:id'}, 'param1=$param1')
+      route.should.eql('/url/:id?param1=$param1');
+    })
+
+    it('should return null if route does not exists', function () {
+      var route = instrument.route();
+      should.not.exist(route);
+    })
+  });
+
+  describe('params', function() {
+    it('should tokenise params', function() {
+      var params = instrument.params({param1: 'value1', param2: 'value2'});
+      params.should.eql('param1=$param1&param2=$param2');
+    });
+  });
+
+});

--- a/test/model/sample.spec.js
+++ b/test/model/sample.spec.js
@@ -49,4 +49,36 @@ describe('sample', function() {
     });
   });
 
+  it('can parse a string response into JSON', function(done) {
+    var server = http.createServer(function(req, res) {
+      res.writeHead(200);
+      res.write(JSON.stringify({ hello: 'world' }));
+      res.end();
+    });
+    var test = this.test;
+    request(server)
+    .get('/foo')
+    .end(function(err, res) {
+      var s = sample.create(test, capture.get().request, capture.get().response);
+      s.response.should.have.property('body', { hello: 'world' });
+      done();
+    });
+  });
+
+  it('can handle a string response that is not JSON', function(done) {
+    var server = http.createServer(function(req, res) {
+      res.writeHead(200);
+      res.write("This is not json");
+      res.end();
+    });
+    var test = this.test;
+    request(server)
+    .get('/foo')
+    .end(function(err, res) {
+      var s = sample.create(test, capture.get().request, capture.get().response);
+      s.response.should.have.property('body', "This is not json");
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
Although supersamples currently works with express, it does not use the route path in the output like it does for restify

e.g. a request to `/foo/:bar` of `/foo/123` will display `/foo/123` rather than `/foo/:bar`

This PR instruments express so that we can get the parameterised route path

- shim the `process_params` function of the express router which is called within the `handle` function
- extract the parameterised route url
- in the captured response, always try to turn into json if the response is a string