### PR TITLE
Ignore certain requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,21 @@ it 'gets a single sport', (done) ->
         .end(done)
     )
 ```
+
+**Ignoring whole tests**
+
+Perhaps you include you docs specs in the same tests as other integration tests that you don't want appearing in your docs
+
+You can exclude them with the following
+
+```js
+it 'backdoor entrance to get a password', (done) ->
+  @supersamples = { ignore: true }
+  request(server)
+    .get('/supersecretthing')
+    .end(done)
+```
+
 **The requests**
 
 - The request headers, including custom ones. However it excludes typically irrelevant headers for the context of documentation (`accept-encoding: gzip, deflate`, `host: http://localhost:1234`...).

--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ it 'gets a list of sports', (done) ->
     .end(done)
 ```
 
+**Ignoring Requests**
+
+Supersamples instruments every request that goes through supertest by default. If you are making multiple requests per `it`, sometimes the results can be a bit problematic as request and responses get merged.
+
+You can explicitly ignore certain requests from being captured by setting the following header
+
+```js
+it 'gets a single sport', (done) ->
+  request(server)
+    .get('/sports')
+    .set('SupersamplesIgnore', 'true')
+    .end((err, response) ->
+      request(server)
+        .get('/sports/' + response.body[0].id)
+        .end(done)
+    )
+```
 **The requests**
 
 - The request headers, including custom ones. However it excludes typically irrelevant headers for the context of documentation (`accept-encoding: gzip, deflate`, `host: http://localhost:1234`...).

--- a/README.md
+++ b/README.md
@@ -23,13 +23,12 @@ Documentation and samples for your Node.js RESTful API
 
 Nothing special! Simply use `supertest` in your test suite, and `supersamples` will generate the request/response documentation for you!
 
-```coffee
-it '''
+```js
+it(`
 # Get list of sports
 - list is ordered alphabetically
 - doesn't return sports with no active competitions
-''', (done) ->
-
+`, function (done) {
   request(server)
     .get('/sports')
     .set('Accept', 'application/json')
@@ -42,6 +41,7 @@ it '''
       ]
     )
     .end(done)
+})
 ```
 
 ## What will the docs look like?
@@ -117,11 +117,12 @@ The `it()` statements can contain valid Markdown, which make up the description 
 By default, the content of the `it` also becomes your sample name. This is used in the `JSON` renderer to help you identify samples. You can also override the name with
 
 ```js
-it 'gets a list of sports', (done) ->
-  @supersamples = { name: 'valid list' }
+it('gets a list of sports', function () {
+  this.supersamples = { name: 'valid list' }
   request(server)
     .get('/sports')
     .end(done)
+})
 ```
 
 **Ignoring Requests**
@@ -131,15 +132,16 @@ Supersamples instruments every request that goes through supertest by default. I
 You can explicitly ignore certain requests from being captured by setting the following header
 
 ```js
-it 'gets a single sport', (done) ->
+it('gets a single sport', function (done) {
   request(server)
     .get('/sports')
     .set('SupersamplesIgnore', 'true')
-    .end((err, response) ->
+    .end(function (err, response) {
       request(server)
-        .get('/sports/' + response.body[0].id)
+        .get(`/sports/${response.body[0].id}`)
         .end(done)
-    )
+    })
+})
 ```
 
 **Ignoring whole tests**
@@ -149,11 +151,12 @@ Perhaps you include you docs specs in the same tests as other integration tests 
 You can exclude them with the following
 
 ```js
-it 'backdoor entrance to get a password', (done) ->
-  @supersamples = { ignore: true }
+it('backdoor entrance to get a password', function (done) {
+  this.supersamples = { ignore: true }
   request(server)
     .get('/supersecretthing')
     .end(done)
+})
 ```
 
 **The requests**

--- a/lib/instruments/supertest.js
+++ b/lib/instruments/supertest.js
@@ -48,6 +48,9 @@ function extractRequest(superTest) {
   if (superTest._data) {
     fields.data = superTest._data;
   }
+  if (fields.headers.supersamplesignore === 'true') {
+    return null;
+  }
   return fields;
 }
 

--- a/lib/instruments/supertest.js
+++ b/lib/instruments/supertest.js
@@ -24,10 +24,14 @@ exports.assert = function(/*[error,] response, fn*/) {
     response = arguments[1];
   }
 
-  capture.add({
-    request: extractRequest(this),
-    response: extractResponse(this, response)
-  });
+  var request = extractRequest(this);
+
+  if (request) {
+    capture.add({
+      request: request,
+      response: extractResponse(this, response)
+    });
+  }
   return this.__shimmed.assert.apply(this, arguments);
 };
 
@@ -36,7 +40,8 @@ exports.assert = function(/*[error,] response, fn*/) {
 var requestHeaderBlacklist = [
   'host',
   'accept-encoding',
-  'user-agent'
+  'user-agent',
+  'supersamplesignore'
 ];
 
 function extractRequest(superTest) {
@@ -48,7 +53,7 @@ function extractRequest(superTest) {
   if (superTest._data) {
     fields.data = superTest._data;
   }
-  if (fields.headers.supersamplesignore === 'true') {
+  if (superTest.req._headers.supersamplesignore === 'true') {
     return null;
   }
   return fields;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -27,7 +27,9 @@ function MyReporter(runner) {
 
   runner.on('pass', function(test) {
     // if we captured anything, it must be an API sample
-    if (capture.hasData()) {
+    var shouldIgnore = test.ctx.supersamples && test.ctx.supersamples.ignore === true
+
+    if (!shouldIgnore && capture.hasData()) {
       var request  = capture.get().request;
       var response = capture.get().response;
       samples.add(sample.create(test, request, response));

--- a/test/end-to-end/express.spec.js
+++ b/test/end-to-end/express.spec.js
@@ -18,6 +18,9 @@ describe('instrument express / supertest / superagent', function() {
     server.post('/foo', function(req, res) {
       res.send({ hello: 'world' })
     })
+    server.post('/foobar', function(req, res) {
+      res.send({ yoyo: 'heyhey' })
+    })
 
     it('inspects the method and path', function(done) {
       request(server)
@@ -84,6 +87,33 @@ describe('instrument express / supertest / superagent', function() {
           route: '/foo'
         });
         done();
+      });
+    });
+
+    it('supports ignoring certain requests', function(done) {
+      request(server)
+      .post('/foo')
+      .set('supersamplesignore', 'true')
+      .send({value: 1234})
+      .end(function() {
+        request(server)
+        .post('/foobar')
+        .send({foo: 'bar'})
+        .end(function() {
+          capture.get().request.should.eql({
+            data: {
+              foo: 'bar'
+            },
+            headers: {
+              'content-type': 'application/json',
+              'content-length': 13
+            },
+            method: 'POST',
+            path: '/foobar',
+            route: '/foobar'
+          });
+          done();
+        });
       });
     });
 


### PR DESCRIPTION
At the moment we capture every single request that comes via supertest
So if for example you make 2 supertest requests in one test it will merge the request payloads of both of these

This will allow you to specifically ignore certain requests

```js
request(server)
    .post(url)
    .set('SupersamplesIgnore', 'true')
    .send(payload)

request(server)
    .post(url2)
    .send(payload2)
```

we will only capture the second request

you can also ignore whole test cases

```js
it('something that should not go in docs', function() {
  this.supersamples = {ignore: true}
  request(server)
    .post(url)
    .set('SupersamplesIgnore', 'true')
    .send(payload)
})
```